### PR TITLE
[Styling] touch up some of the styling

### DIFF
--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -12,7 +12,7 @@
 en: &DEFAULT_EN
   header:
     title: Hello and welcome to the
-    text: Swansea Uni Tree Society!
+    text: Swansea University Tree Society!
     button: Tell Me More
     buttonlink: "#services"
 

--- a/_includes/socials.html
+++ b/_includes/socials.html
@@ -8,14 +8,14 @@
         <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].socials.text | default: "" }}</h3>
       </div>
     </div>
-    <div class="row">
+    <div class="row align-items-center">
       {% for page in site.data.sitetext[site.locale].socials.pages %}
       <div class="col-lg-3 col-6">
         <div class="socials-member">
           <a href="{{ page.url | default: # }}">
             <img class="mx-auto rounded-circle" src="{{ page.image | default: assets/img/team/placeholder.jpg }}"></img>
           </a>
-          <h5>{{ page.name }}</h4>
+          <h5 class="text-muted">{{ page.name }}</h4>
         </div>
       </div>
         {% endfor %}

--- a/_includes/socials.html
+++ b/_includes/socials.html
@@ -15,7 +15,7 @@
           <a href="{{ page.url | default: # }}">
             <img class="mx-auto rounded-circle" src="{{ page.image | default: assets/img/team/placeholder.jpg }}"></img>
           </a>
-          <h5 class="text-muted">{{ page.name }}</h4>
+          <h5 class="text-muted">{{ page.name }}</h5>
         </div>
       </div>
         {% endfor %}
@@ -41,14 +41,14 @@
         <h3 class="section-subheading text-muted">{{ site.data.sitetext.socials.text | default: "" }}</h3>
       </div>
     </div>
-    <div class="row">
+    <div class="row align-items-center">
       {% for page in site.data.sitetext.socials.pages %}
       <div class="col-lg-3 col-6">
         <div class="socials-member">
           <a href="{{ page.url | default: # }}">
             <img class="mx-auto rounded-circle" src="{{ page.image | default: assets/img/team/placeholder.jpg }}"></img>
           </a>
-          <h5>{{ page.name }}</h4>
+          <h5 class="text-muted">{{ page.name }}</h5>
         </div>
       </div>
         {% endfor %}

--- a/_sass/layout/_about.scss
+++ b/_sass/layout/_about.scss
@@ -1,0 +1,7 @@
+// Styling for the about section
+#about {
+    padding: 100px 0 50px 0;
+    img {
+        margin-bottom: 2.2rem;
+    }
+}

--- a/_sass/layout/_socials.scss
+++ b/_sass/layout/_socials.scss
@@ -11,8 +11,8 @@
   img:hover {
     border: 7px solid fade-out($primary, 0)
   }
-  h4 {
-    margin-top: 25px;
+  h5 {
+    margin-top: 1rem;
     margin-bottom: 0;
     text-transform: none;
   }

--- a/assets/css/agency.scss
+++ b/assets/css/agency.scss
@@ -28,6 +28,7 @@ $contact-image: "{{ site.data.style.contact-image }}";
 @import "layout/socials.scss";
 @import "layout/helping.scss";
 @import "layout/portfolio.scss";
+@import "layout/about.scss";
 @import "layout/timeline.scss";
 @import "layout/team.scss";
 @import "layout/contact.scss";


### PR DESCRIPTION
This PR addresses issue https://github.com/SwanseaCompSci/tree-society-website/issues/7

Changes:
- Changed the text under each social media logo to be a muted colour, applied `align-items-center` and adjusted the top margin
- Adjusted the bottom padding of the About section and added some extra margin between the bottom of the logo and the body text
- Changed "Swansea Uni" in the landing section to "Swansea University" to address the mistake in commit https://github.com/SwanseaCompSci/tree-society-website/commit/7c6e55eda2e3cea1ab3daaab62bd603e6ec9f8e8