### PR TITLE
fix alignment of some sections on mobile view

### DIFF
--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -30,7 +30,7 @@
         </div>
       </div>
     </div>
-    <div class="row">
+    <div class="row justify-content-center">
 	{% for project in site.portfolio %}
       <div class="col-md-4 col-sm-6 portfolio-item">
         <a class="portfolio-link" data-toggle="modal" href="#p{{ forloop.index }}">
@@ -74,7 +74,7 @@
         <h4>{{ site.data.sitetext.portfolio.trees_planted_this_year | times: 100 | divided_by: site.data.sitetext.portfolio.trees_goal }}%</h4>
       </div>
     </div>
-    <div class="row">
+    <div class="row justify-content-center">
       <div class="col-lg-12 goal-progress">
         <div class="progress">
           <div class="progress-bar progress-bar-striped progress-bar-animated bg-success" role="progressbar" style="width: {{ site.data.sitetext.portfolio.trees_planted_this_year | times: 100 | divided_by: site.data.sitetext.portfolio.trees_goal }}%" aria-valuenow="{{ site.data.sitetext.portfolio.trees_planted_this_year | times: 100 | divided_by: site.data.sitetext.portfolio.trees_goal }}" aria-valuemin="0" aria-valuemax="100"></div>

--- a/_includes/socials.html
+++ b/_includes/socials.html
@@ -8,7 +8,7 @@
         <h3 class="section-subheading text-muted">{{ site.data.sitetext[site.locale].socials.text | default: "" }}</h3>
       </div>
     </div>
-    <div class="row align-items-center">
+    <div class="row align-items-center justify-content-center">
       {% for page in site.data.sitetext[site.locale].socials.pages %}
       <div class="col-lg-4 col-6">
         <div class="socials-member">
@@ -41,7 +41,7 @@
         <h3 class="section-subheading text-muted">{{ site.data.sitetext.socials.text | default: "" }}</h3>
       </div>
     </div>
-    <div class="row align-items-center">
+    <div class="row align-items-center justify-content-center">
       {% for page in site.data.sitetext.socials.pages %}
       <div class="col-lg-4 col-6">
         <div class="socials-member">

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -10,7 +10,7 @@
   </div>
   <div class="row">
   {% for person in site.data.sitetext[site.locale].team.people %}
-	<div class="col-sm-3">
+	<div class="col-lg-3 col-md-6">
 	  <div class="team-member">
 		<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 		<h4>{{ person.name }}</h4>
@@ -46,7 +46,7 @@
 	  </div>
 	  <div class="row">
 	  {% for person in site.data.sitetext.team.people %}
-		<div class="col-sm-3">
+		<div class="col-lg-3 col-md-6">
 		  <div class="team-member">
 			<img class="mx-auto rounded-circle" src="{{ person.image }}" alt="">
 			<h4>{{ person.name }}</h4>


### PR DESCRIPTION
This PR addresses the following:

- #21 
- Apply `justify-content-center` to portfolio items so that the third item is centered when the viewport width is between 575px and 768px
- Change how the committee members collapse between viewport widths so that they do not overlap between the `lg` and `sm` Bootstrap breakpoints