### PR TITLE
Reset counter of trees planted this year to 0

### DIFF
--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -57,7 +57,7 @@ en: &DEFAULT_EN
   portfolio: # tree planting - each season modal is created from markdown files in /_portfolio/
     title: "Tree Planting"
     trees_planted_total: 15420 # these numbers will need to be updated manually for now
-    trees_planted_this_year: 8990
+    trees_planted_this_year: 0
     trees_goal: 1000
     section: portfolio
     closebutton: "Close"


### PR DESCRIPTION
## Describe your changes
As it is a new academic year and no trees have been planted yet, it was necessary to reset the counter of trees planted this year to 0.

## Checklist before requesting a review
- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation and comments where neccessary
- [x] If the changes affect the website, I have tested the branch using `bundle exec jekyll serve` on my local machine
