### PR TITLE
Changed font for navbar brand to Patua One

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -27,7 +27,7 @@
   <!-- Custom fonts for this template -->
   <link href="assets/css/all.min.css" rel="stylesheet" type="text/css">
   <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
-  <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Patua+One' rel='stylesheet' type='text/css'>
   <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
   <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 

--- a/_sass/components/_navbar.scss
+++ b/_sass/components/_navbar.scss
@@ -49,7 +49,8 @@
       border: none;
       background-color: transparent;
       .navbar-brand {
-        font-size: 1.75em;
+        font-family: "Patua One";
+        font-size: 1.6em;
         -webkit-transition: all 0.3s;
         -moz-transition: all 0.3s;
         transition: all 0.3s;


### PR DESCRIPTION
## Describe your changes
Jean-Louis asked for font of the title in the navbar to be changed to one similar to the font used in the logo. I changed it to Patua One, as this seems very similar to the font in the logo.

## Checklist before requesting a review
- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation and comments where neccessary
- [x] If the changes affect the website, I have tested the branch using `bundle exec jekyll serve` on my local machine
