### PR TITLE
Fix typo in Zambia Discovery SVS description

### DIFF
--- a/_data/sitetext.yml
+++ b/_data/sitetext.yml
@@ -85,7 +85,7 @@ en: &DEFAULT_EN
         alt: "UN Refugee Agency"
         funds_raised: 467.67
       - title: "Zambia community group, Discovery SVS"
-        desc: "Money was raised for a community group that we volunteered with when the Swansea University's Discovery SVS team ran a 4 week trip to Zambia in 2019.**"
+        desc: "Money was raised for a community group that we volunteered with when the Swansea University's Discovery SVS team ran a 4 week trip to Zambia in 2019."
         image: assets/img/timeline/discovery.png
         alt: "Zambia group"
         funds_raised: 663.75


### PR DESCRIPTION
## Describe your changes
Removed `**` from the end of the Zambia Discovery SVS description after merging PR for issue #56 

## Issue ticket number and link
#56 

## Checklist before requesting a review
- [x] I have performed a self-review of my changes
- [x] I have made corresponding changes to the documentation and comments where neccessary
- [x] If the changes affect the website, I have tested the branch using `bundle exec jekyll serve` on my local machine
